### PR TITLE
feat: Refactor user creation logic

### DIFF
--- a/app/Http/Controllers/Dashboard/UserController.php
+++ b/app/Http/Controllers/Dashboard/UserController.php
@@ -44,7 +44,7 @@ class UserController extends Controller
 
     public function store(StoreUserRequest $request, UsersService $service): RedirectResponse
     {
-        $user = $this->init($service)->createUser($request->validated());
+        $user = $this->initialize($service,$request)->createUser($request->validated());
 
         return redirect()
             ->route('dashboard.users')

--- a/app/Http/Controllers/Dashboard/UserController.php
+++ b/app/Http/Controllers/Dashboard/UserController.php
@@ -44,7 +44,7 @@ class UserController extends Controller
 
     public function store(StoreUserRequest $request, UsersService $service): RedirectResponse
     {
-        $user = $this->initialize($service , $request)->createUser();
+        $user = $this->init($service)->createUser($request->validated());
 
         return redirect()
             ->route('dashboard.users')

--- a/app/Models/Upload.php
+++ b/app/Models/Upload.php
@@ -8,6 +8,12 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 class Upload extends Model
 {
 
+    protected $fillable = [
+        'name',
+        'path',
+        'mime_type',
+        'size'
+    ];
 
     public function uploadable():MorphTo
     {

--- a/app/Models/Upload.php
+++ b/app/Models/Upload.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Upload extends Model
+{
+
+
+    public function uploadable():MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Models\Profile;
 use App\Enums\UserAccountStatus;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -57,5 +58,12 @@ class User extends Model
         return $this->hasOne(Profile::class);
 
     }
+
+    public function upload():MorphOne
+    {
+        return $this->morphOne(Upload::class, 'uploadable');
+    }
+
+
 
 }

--- a/app/Traits/HandlesUserOperations.php
+++ b/app/Traits/HandlesUserOperations.php
@@ -67,19 +67,20 @@ trait HandlesUserOperations
 
         $path = $profileImage->storeAs('profile',$profileImage->hashName(), 'public' );
 
+
         $mimiType = $profileImage->getMimeType();
 
         $originalFilename = $profileImage->getClientOriginalName()      ;
 
-        ds($originalFilename);
-
-        return $this->usersService->create([
+        $user = $this->usersService->createUser([
             'first_name' => $validated['first_name'],
             'last_name' => $validated['last_name'],
             'username' => $validated['username'],
             'email' => $validated['email'],
             'password' => $validated['password'],
-        ], [
+        ]);
+
+        $profile = $this->usersService->createProfile([
             'bio' => $validated['bio'],
             'github_repo_url' => $validated['github_repo_url'],
             'date_of_birth' => $validated['date_of_birth'],
@@ -94,7 +95,16 @@ trait HandlesUserOperations
             'x' => $validated['x'],
             'instagram' => $validated['instagram'],
             'facebook' => $validated['facebook'],
-        ]);
+        ])  ;
+
+        $upload = $this->usersService->uploadProfileImage([
+            'name' => $originalFilename,
+            'path' => $path,
+            'mime_type' => $profileImage->getMimeType(),
+            'size' => $profileImage->getSize(),
+        ])  ;
+
+        return $user;
     }
 
 }

--- a/app/Traits/HandlesUserOperations.php
+++ b/app/Traits/HandlesUserOperations.php
@@ -61,10 +61,9 @@ trait HandlesUserOperations
 
     }
 
-    public function createUser()
+    public function createUser(mixed $validated)
     {
-        ds($this->request);
-/*        return $this->usersService->create([
+        return $this->usersService->create([
             'first_name' => $validated['first_name'],
             'last_name' => $validated['last_name'],
             'username' => $validated['username'],
@@ -86,7 +85,7 @@ trait HandlesUserOperations
             'x' => $validated['x'],
             'instagram' => $validated['instagram'],
             'facebook' => $validated['facebook'],
-        ]);*/
+        ]);
     }
 
 }

--- a/app/Traits/HandlesUserOperations.php
+++ b/app/Traits/HandlesUserOperations.php
@@ -63,6 +63,7 @@ trait HandlesUserOperations
 
     public function createUser(mixed $validated)
     {
+        @ds($this->request);
         return $this->usersService->create([
             'first_name' => $validated['first_name'],
             'last_name' => $validated['last_name'],

--- a/app/services/UsersService.php
+++ b/app/services/UsersService.php
@@ -25,6 +25,10 @@ class UsersService
 
     protected string $orderDir;
 
+    protected User $user;
+
+    protected Profile $profile;
+
 
 
     public function __construct(Builder $query, string $term , array|string $searchBy = []  , array $filters = [], string $orderBy = 'id', string $orderDir = 'asc')
@@ -149,9 +153,39 @@ class UsersService
         return $this;
     }
 
-    public function create(array $user , array $profile)
+    public function createUser(array $user , array $profile, array $image = []): static
     {
-        return User::create($user)->profile()->create($profile);
+        $this->user = User::create($user);
+
+        return $this;
+/*
+        if($createdUser){
+            $createdUser->profile()->create($profile);
+
+        }
+        if($image !== []){
+            $createdUser->upload()->create($image);
+        }
+
+        return $createdUser;*/
+    }
+
+    public function createProfile(array $profile): static
+    {
+        if(isset($this->user)){
+            $this->user->profile()->create($profile);
+        }
+
+        return $this;
+    }
+
+    public function uploadProfileImage(array $image): static
+    {
+          if(isset($this->user->profile, $this->user)){
+              $this->user->upload()->create($image);
+          }
+
+          return $this;
     }
 
 

--- a/app/services/UsersService.php
+++ b/app/services/UsersService.php
@@ -3,6 +3,7 @@
 namespace App\services;
 
 use App\Models\Profile;
+use App\Models\Upload;
 use Exception;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
@@ -28,6 +29,7 @@ class UsersService
     protected User $user;
 
     protected Profile $profile;
+    protected Upload $upload;
 
 
 
@@ -153,39 +155,29 @@ class UsersService
         return $this;
     }
 
-    public function createUser(array $user , array $profile, array $image = []): static
+    public function createUser(array $user): User
     {
         $this->user = User::create($user);
 
-        return $this;
-/*
-        if($createdUser){
-            $createdUser->profile()->create($profile);
-
-        }
-        if($image !== []){
-            $createdUser->upload()->create($image);
-        }
-
-        return $createdUser;*/
+        return $this->user;
     }
 
-    public function createProfile(array $profile): static
+    public function createProfile(array $profile):Profile
     {
         if(isset($this->user)){
-            $this->user->profile()->create($profile);
+           $this->profile = $this->user->profile()->create($profile);
         }
 
-        return $this;
+        return $this->profile;
     }
 
-    public function uploadProfileImage(array $image): static
+    public function uploadProfileImage(array $image): Upload
     {
-          if(isset($this->user->profile, $this->user)){
-              $this->user->upload()->create($image);
+          if(isset($this->profile, $this->user)){
+             $this->upload = $this->user->upload()->create($image);
           }
 
-          return $this;
+          return $this->upload;
     }
 
 

--- a/database/migrations/2025_11_03_150259_create_uploads_table.php
+++ b/database/migrations/2025_11_03_150259_create_uploads_table.php
@@ -13,11 +13,11 @@ return new class extends Migration
     {
         Schema::create('uploads', static function (Blueprint $table) {
             $table->id();
-            $table->string('name');
-            $table->string('path');
+            $table->string('name')->nullable();
+            $table->string('path')->nullable();
             $table->morphs('uploadable');
-            $table->string('mime_type');
-            $table->integer('size');
+            $table->string('mime_type')->nullable();
+            $table->integer('size')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_11_03_150259_create_uploads_table.php
+++ b/database/migrations/2025_11_03_150259_create_uploads_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('uploads', static function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('path');
+            $table->morphs('uploadable');
+            $table->string('mime_type');
+            $table->integer('size');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('uploads');
+    }
+};

--- a/tests/DataProviders/UsersServiceTestsDataProvider.php
+++ b/tests/DataProviders/UsersServiceTestsDataProvider.php
@@ -3,10 +3,10 @@
 namespace Tests\DataProviders;
 
 use App\Enums\Countries;
-use App\Models\Profile;
-use App\Models\User;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Faker\Factory as FakerFactory;
+use Illuminate\Support\Facades\Storage;
 
 class UsersServiceTestsDataProvider
 {
@@ -134,6 +134,9 @@ class UsersServiceTestsDataProvider
         $faker = FakerFactory::create();
         $country = $faker->randomElement(Countries::getAllCountries());
         $city = collect(Countries::getCities($country))->random();
+        $profile_picture = UploadedFile::fake()->create('avatar.png', 20000,'image/png');
+
+
         return [
              'create' => [
                  'passedCreation' => [
@@ -152,6 +155,12 @@ class UsersServiceTestsDataProvider
                          'country' => $country,
                          'city' => $city
 
+                     ],
+                     'profile_picture' => [
+                         'name' => $profile_picture->getClientOriginalName(),
+                         'path' => $profile_picture->path(),
+                         'mime_type' => $profile_picture->getMimeType(),
+                         'size' => $profile_picture->getSize(),
                      ]
                  ]
              ]

--- a/tests/Feature/UsersServiceTest.php
+++ b/tests/Feature/UsersServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Upload;
 use Tests\TestCase;
 use App\Models\User;
 use App\Models\Profile;
@@ -321,7 +322,8 @@ class UsersServiceTest extends TestCase
              ->assertDatabaseCount('users', 1)
              ->assertDatabaseCount('profiles', 1)
              ->assertModelExists($user)
-             ->assertModelExists($user->profile);
+             ->assertModelExists($user->profile)
+             ->assertModelMissing(Upload::class);
 
 
 

--- a/tests/Feature/UsersServiceTest.php
+++ b/tests/Feature/UsersServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Upload;
+use Illuminate\Http\UploadedFile;
 use Tests\TestCase;
 use App\Models\User;
 use App\Models\Profile;
@@ -316,19 +317,72 @@ class UsersServiceTest extends TestCase
 
          $service = UsersTestsHelpers::createUsersService();
 
-         $user =  $service->create($user, $profile);
+         $user =  $service->createUser($user);
 
          $this
              ->assertDatabaseCount('users', 1)
-             ->assertDatabaseCount('profiles', 1)
              ->assertModelExists($user)
-             ->assertModelExists($user->profile)
+             ->assertModelMissing(Profile::class)
              ->assertModelMissing(Upload::class);
 
+    }
 
+    /**
+     * @throws BindingResolutionException
+     */
+    #[Test]
+    #[DataProviderExternal(UsersServiceTestsDataProvider::class,'createNewUserProvider')]
+    public function admin_create_new_user_and_profile_add_record_to_database(array $passedCreation):void
+    {
+        extract($passedCreation);
 
+        $service = UsersTestsHelpers::createUsersService();
 
+        $user = $service->createUser($user);
 
+        $profile = $service->createProfile($profile);
+
+        $this->assertDatabaseCount('users', 1);
+
+        $this->assertModelExists($user);
+
+        $this->assertDatabaseCount('profiles', 1);
+
+        $this->assertModelExists($profile);
+
+        $this->assertModelMissing(Upload::class);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    #[Test]
+    #[DataProviderExternal(UsersServiceTestsDataProvider::class,'createNewUserProvider')]
+    public function admin_create_new_user_and_profile_upload_profile_image_add_record_to_database(array $passedCreation): void
+    {
+        extract($passedCreation);
+
+        $service = UsersTestsHelpers::createUsersService();
+
+        $user = $service->createUser($user);
+
+        $profile = $service->createProfile($profile);
+
+        $upload = $service->uploadProfileImage($profile_picture);
+
+        ds($upload);
+
+        $this->assertDatabaseCount('users', 1);
+
+        $this->assertModelExists($user);
+
+        $this->assertDatabaseCount('profiles', 1);
+
+        $this->assertModelExists($profile);
+
+        $this->assertDatabaseCount('uploads', 1);
+
+        $this->assertModelExists($upload);
     }
 
 


### PR DESCRIPTION
This commit refactors the user creation process to improve code clarity and maintainability.

The following changes have been made:

- In `UserController`, the `store` method has been updated to use the `init` method instead of `initialize`.
- The `createUser` method in `HandlesUserOperations` now accepts the validated request data as an argument, making the method more explicit and easier to test.
- The user creation logic in `HandlesUserOperations` has been uncommented and updated to use the validated data.

These changes streamline the user creation process and make the code more robust.